### PR TITLE
Require psalm v3 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "vimeo/psalm": "dev-master"
+        "vimeo/psalm": "^3"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.3",


### PR DESCRIPTION
This way, projects depending on fkupper/psalm-laravel-collections don't
need to also require vimeo/psalm=dev-master