### PR TITLE
Also allow Psalm v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "vimeo/psalm": "^3"
+        "vimeo/psalm": "^3||^4"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.3",


### PR DESCRIPTION
I'm back with a small patch, while trying to upgrade our psalm dependency to v4, I found out that `^3` actually means 'any `3.y.z`' release, therefore I amended it to `^3||^4`, so v4 releases also work.

As a side note: would it be possible that you release a new tag on packagist.org, so our auto-updater can pick up this library?